### PR TITLE
maven/tycho 1.0.0 pomless build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# maven tycho build output
+target
+
 *.pydevproject
 .metadata
 .gradle

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho.extras</groupId>
+    <artifactId>tycho-pomless</artifactId>
+    <version>1.0.0</version>
+  </extension>
+</extensions>

--- a/csvedit.site/category.xml
+++ b/csvedit.site/category.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/org.fhsolution.eclipse.feature.csvedit_1.2.0.qualifier.jar" 
+  					  id="org.fhsolution.eclipse.feature.csvedit" version="1.2.0.qualifier">
+      <category name="tools"/>
+   </feature>
+   <category-def name="tools" label="Tools"/>
+</site>

--- a/csvedit.site/pom.xml
+++ b/csvedit.site/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>csvedit</artifactId>
+		<groupId>org.nodeclipse</groupId>
+		<version>1.2.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>csvedit.site</artifactId>
+	<packaging>eclipse-repository</packaging>
+	<name>csvedit :: update site</name>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.nodeclipse</groupId>
+  <artifactId>csvedit</artifactId>
+  <version>1.2.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>csvedit :: parent</name>
+  <description>csvedit parent</description>
+
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+
+  <properties>
+    <java.version>1.6</java.version>
+  	<maven.version>3.0</maven.version>
+  	<tycho.version>1.0.0</tycho.version>
+  	<tycho.test.jvmArgs>-Xmx512m -XX:MaxPermSize=256m</tycho.test.jvmArgs>
+  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>luna</id>
+      <layout>p2</layout>
+      <url>http://download.eclipse.org/releases/luna</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype-public</id>
+      <url>http://repository.sonatype.org/content/groups/sonatype-public-grid</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <resolver>p2</resolver>
+          <pomDependencies>consider</pomDependencies>
+          <ignoreTychoRepositories>true</ignoreTychoRepositories>
+        </configuration>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-packaging-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <format>yyyyMMdd-HHmm</format>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <useUIHarness>true</useUIHarness>
+            <includes>
+              <include>**/*Test.java</include>
+            </includes>
+            <argLine>${tycho.test.jvmArgs}</argLine>
+            <!-- kill test JVM if tests take more than 1 minute (60 seconds) to finish -->
+            <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
+          </configuration>
+        </plugin>
+        <plugin>
+        	<groupId>org.apache.maven.plugins</groupId>
+        	<artifactId>maven-assembly-plugin</artifactId>
+        	<version>2.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>  
+  <modules>
+    <module>csvedit.plugin</module>
+    <module>csvedit.plugin.ui</module>
+    <module>csvedit.feature</module>
+    <!-- 
+     -->
+    <module>csvedit.site</module>
+  </modules>
+</project>


### PR DESCRIPTION
tycho build can be used in parallel to main Eclipse RCP build, no need to convert project to maven project.

As with any maven project `mvn package` to build. However Eclipse tycho would behave a bit differently and download a lot.


https://eclipse.org/tycho/  
https://wiki.eclipse.org/Tycho/Release_Notes/1.0.0  
https://www.eclipse.org/tycho/sitedocs/  
pomless:  
https://wiki.eclipse.org/Tycho/Release_Notes/0.24  